### PR TITLE
fix: Corrige caminhos de imagem para serem absolutos em todo o site

### DIFF
--- a/FRONT/catalogo/js/catalogo.js
+++ b/FRONT/catalogo/js/catalogo.js
@@ -12,7 +12,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 <div class="product-card" data-id="${product.id}">
                     <a href="../../produto/HTML/produto.html?id=${product.id}" class="product-card-link">
                         <div class="product-image-wrapper">
-                            <img src="../../${product.imagemUrl}" onerror="this.onerror=null;this.src='https.via.placeholder.com/400x400.png?text=Imagem+Indisponível';" alt="${product.nome}">
+                            <img src="/${product.imagemUrl}" onerror="this.onerror=null;this.src='https.via.placeholder.com/400x400.png?text=Imagem+Indisponível';" alt="${product.nome}">
                         </div>
                         <div class="product-info">
                             <span class="product-brand">${product.marca.nome}</span>

--- a/FRONT/inicio/js/recentes.js
+++ b/FRONT/inicio/js/recentes.js
@@ -7,9 +7,9 @@ document.addEventListener("DOMContentLoaded", () => {
     container.innerHTML = productsToRender.map(product => `
       <div class="swiper-slide">
         <div class="product-card" data-id="${product.id}">
-          <a href="FRONT/produto/HTML/produto.html?id=${product.id}" class="product-card-link">
+          <a href="/FRONT/produto/HTML/produto.html?id=${product.id}" class="product-card-link">
             <div class="product-image-wrapper">
-              <img src="${product.imagemUrl}" onerror="this.onerror=null;this.src='https.via.placeholder.com/400x400.png?text=Imagem+Indisponível';" alt="${product.nome}">
+              <img src="/${product.imagemUrl}" onerror="this.onerror=null;this.src='https.via.placeholder.com/400x400.png?text=Imagem+Indisponível';" alt="${product.nome}">
             </div>
             <div class="product-info">
               <span class="product-brand">${product.marca.nome}</span>
@@ -71,7 +71,7 @@ document.addEventListener("DOMContentLoaded", () => {
           id: product.id.toString(),
           name: product.nome,
           price: product.preco,
-          image: `${product.imagemUrl}`,
+          image: `/${product.imagemUrl}`,
           size: '39' // Tamanho padrão para adição rápida
         };
         if (window.addToCart) {


### PR DESCRIPTION
- Em `recentes.js` e `catalogo.js`, os caminhos das imagens foram prefixados com `/` para torná-los absolutos a partir da raiz do site. Isso resolve os erros 404 que ocorriam dependendo da página em que os produtos eram exibidos.
- Adiciona um `onerror` handler às tags `img` em ambos os arquivos para exibir uma imagem de fallback caso a imagem principal não carregue.